### PR TITLE
MX-14060: add ClearStorage() func

### DIFF
--- a/disabled/persister.go
+++ b/disabled/persister.go
@@ -46,6 +46,11 @@ func (p *persister) DestroyClosed() error {
 	return nil
 }
 
+// Clear returns nil
+func (p *persister) Clear() error {
+	return nil
+}
+
 // RangeKeys does nothing
 func (p *persister) RangeKeys(_ func(key []byte, val []byte) bool) {}
 

--- a/leveldb/common.go
+++ b/leveldb/common.go
@@ -74,9 +74,10 @@ func openOneTime(path string, options *opt.Options) (*leveldb.DB, error) {
 }
 
 type baseLevelDb struct {
-	mutDb sync.RWMutex
-	path  string
-	db    *leveldb.DB
+	mutDb   sync.RWMutex
+	path    string
+	options *opt.Options
+	db      *leveldb.DB
 }
 
 func (bldb *baseLevelDb) getDbPointer() *leveldb.DB {

--- a/leveldb/leveldb.go
+++ b/leveldb/leveldb.go
@@ -153,7 +153,10 @@ func (s *DB) updateBatchWithIncrement() error {
 
 // Put adds the value to the (key, val) storage medium
 func (s *DB) Put(key, val []byte) error {
+	s.mutBatch.RLock()
 	err := s.batch.Put(key, val)
+	s.mutBatch.RUnlock()
+
 	if err != nil {
 		return err
 	}

--- a/leveldb/leveldb.go
+++ b/leveldb/leveldb.go
@@ -70,8 +70,9 @@ func NewDB(path string, batchDelaySeconds int, maxBatchSize int, maxOpenFiles in
 	sw.Stop(openLevelDBFunction)
 
 	bldb := &baseLevelDb{
-		db:   db,
-		path: path,
+		db:      db,
+		path:    path,
+		options: options,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -253,6 +254,25 @@ func (s *DB) Close() error {
 	}
 
 	return nil
+}
+
+// Clear will destroy the database and create it again
+func (s *DB) Clear() error {
+	err := s.Close()
+	if err != nil {
+		return err
+	}
+
+	err = s.DestroyClosed()
+	if err != nil {
+		return err
+	}
+
+	s.mutDb.Lock()
+	s.db, err = openLevelDB(s.path, s.options)
+	s.mutDb.Unlock()
+
+	return err
 }
 
 // Remove removes the data associated to the given key

--- a/leveldb/leveldbSerial.go
+++ b/leveldb/leveldbSerial.go
@@ -65,8 +65,9 @@ func NewSerialDB(path string, batchDelaySeconds int, maxBatchSize int, maxOpenFi
 	sw.Stop(openLevelDBFunction)
 
 	bldb := &baseLevelDb{
-		db:   db,
-		path: path,
+		db:      db,
+		path:    path,
+		options: options,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -315,6 +316,25 @@ func (s *SerialDB) DestroyClosed() error {
 	if err != nil {
 		log.Error("error destroy closed", "error", err, "path", s.path)
 	}
+	return err
+}
+
+// Clear will destroy the database and create it again
+func (s *SerialDB) Clear() error {
+	err := s.Close()
+	if err != nil {
+		return err
+	}
+
+	err = s.DestroyClosed()
+	if err != nil {
+		return err
+	}
+
+	s.mutDb.Lock()
+	s.db, err = openLevelDB(s.path, s.options)
+	s.mutDb.Unlock()
+
 	return err
 }
 

--- a/leveldb/leveldb_test.go
+++ b/leveldb/leveldb_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"sync"
 	"testing"
 	"time"
 
@@ -321,6 +322,64 @@ func TestDB_MethodCallsAfterCloseOrDestroy(t *testing.T) {
 			_ = db.Destroy()
 		})
 	})
+}
+
+func TestDB_Clear(t *testing.T) {
+	ldb := createSerialLevelDb(t, 10, 1, 10)
+
+	testKey, testVal := []byte("key"), []byte("value")
+	_ = ldb.Put(testKey, testVal)
+
+	res, err := ldb.Get(testKey)
+	assert.Equal(t, testVal, res)
+	assert.Nil(t, err)
+
+	err = ldb.Clear()
+	assert.Nil(t, err)
+}
+
+func TestDB_ConcurrentOperations(t *testing.T) {
+	ldb := createLevelDb(t, 10, 1, 10)
+
+	numOps := 30
+	wg := sync.WaitGroup{}
+	wg.Add(numOps)
+
+	for i := 0; i < numOps; i++ {
+		go func(idx int) {
+			modRes := idx % 10
+			testKey := []byte(fmt.Sprintf("%d", modRes))
+			testVal := testKey
+			switch modRes {
+			case 0:
+				_ = ldb.Clear()
+			case 1:
+				_ = ldb.Close()
+			case 2:
+				_ = ldb.Destroy()
+			case 3:
+				_ = ldb.DestroyClosed()
+			case 4:
+				_, _ = ldb.Get(testKey)
+			case 5:
+				_ = ldb.Has(testKey)
+			case 6:
+				ldb.IsInterfaceNil()
+			case 7:
+				_ = ldb.Put(testKey, testVal)
+			case 8:
+				ldb.RangeKeys(func(key []byte, value []byte) bool {
+					return true
+				})
+			case 9:
+				_ = ldb.Remove(testKey)
+			}
+
+			wg.Done()
+		}(i)
+	}
+
+	wg.Wait()
 }
 
 func testDbAllMethodsShouldNotPanic(t *testing.T, closeHandler func(db *leveldb.DB)) {

--- a/memorydb/lruMemoryDB.go
+++ b/memorydb/lruMemoryDB.go
@@ -59,6 +59,13 @@ func (l *lruDB) Close() error {
 	return nil
 }
 
+// Clear will clean the cacher
+func (l *lruDB) Clear() error {
+	l.cacher.Clear()
+
+	return nil
+}
+
 // Remove removes the data associated to the given key
 func (l *lruDB) Remove(key []byte) error {
 	l.cacher.Remove(key)

--- a/memorydb/memorydb.go
+++ b/memorydb/memorydb.go
@@ -89,6 +89,16 @@ func (s *DB) Destroy() error {
 	return nil
 }
 
+// Clear will clear the internal map
+func (s *DB) Clear() error {
+	s.mutx.Lock()
+	defer s.mutx.Unlock()
+
+	s.db = make(map[string][]byte)
+
+	return nil
+}
+
 // RangeKeys will iterate over all contained (key, value) pairs calling the provided handler
 func (s *DB) RangeKeys(handler func(key []byte, value []byte) bool) {
 	if handler == nil {

--- a/storageUnit/nilStorer.go
+++ b/storageUnit/nilStorer.go
@@ -73,8 +73,8 @@ func (ns *NilStorer) Remove(_ []byte) error {
 func (ns *NilStorer) ClearCache() {
 }
 
-// ClearStorage returns nil
-func (ns *NilStorer) ClearStorage() error {
+// Clear returns nil
+func (ns *NilStorer) Clear() error {
 	return nil
 }
 

--- a/storageUnit/nilStorer.go
+++ b/storageUnit/nilStorer.go
@@ -73,6 +73,11 @@ func (ns *NilStorer) Remove(_ []byte) error {
 func (ns *NilStorer) ClearCache() {
 }
 
+// ClearStorage returns nil
+func (ns *NilStorer) ClearStorage() error {
+	return nil
+}
+
 // DestroyUnit will do nothing
 func (ns *NilStorer) DestroyUnit() error {
 	return nil

--- a/storageUnit/storageunit.go
+++ b/storageUnit/storageunit.go
@@ -110,7 +110,6 @@ type Unit struct {
 	lock      sync.RWMutex
 	persister types.Persister
 	cacher    types.Cacher
-	argsNewDB ArgDB
 }
 
 // Put adds data to both cache and persistence medium
@@ -282,7 +281,7 @@ func (u *Unit) IsInterfaceNil() bool {
 
 // NewStorageUnit is the constructor for the storage unit, creating a new storage unit
 // from the given cacher and persister.
-func NewStorageUnit(c types.Cacher, p types.Persister, argsNewDB ArgDB) (*Unit, error) {
+func NewStorageUnit(c types.Cacher, p types.Persister) (*Unit, error) {
 	if check.IfNil(p) {
 		return nil, common.ErrNilPersister
 	}
@@ -293,7 +292,6 @@ func NewStorageUnit(c types.Cacher, p types.Persister, argsNewDB ArgDB) (*Unit, 
 	sUnit := &Unit{
 		persister: p,
 		cacher:    c,
-		argsNewDB: argsNewDB,
 	}
 
 	return sUnit, nil
@@ -329,7 +327,7 @@ func NewStorageUnitFromConf(cacheConf CacheConfig, dbConf DBConfig) (*Unit, erro
 		return nil, err
 	}
 
-	return NewStorageUnit(cache, db, argDB)
+	return NewStorageUnit(cache, db)
 }
 
 // NewCache creates a new cache from a cache config

--- a/storageUnit/storageunit.go
+++ b/storageUnit/storageunit.go
@@ -260,24 +260,18 @@ func (u *Unit) DestroyUnit() error {
 	return u.persister.Destroy()
 }
 
-// ClearStorage will clean the storer by removing the database and creating a new one at the same location
-func (u *Unit) ClearStorage() error {
+// Clear will clean the storer by removing the database and creating a new one at the same location
+func (u *Unit) Clear() error {
 	u.lock.Lock()
 	defer u.lock.Unlock()
 
-	err := u.persister.Close()
-	if err != nil {
-		return err
-	}
-
-	err = u.persister.DestroyClosed()
+	err := u.persister.Clear()
 	if err != nil {
 		return err
 	}
 
 	u.ClearCache()
 
-	u.persister, err = NewDB(u.argsNewDB)
 	return err
 }
 

--- a/storageUnit/storageunit_test.go
+++ b/storageUnit/storageunit_test.go
@@ -21,20 +21,12 @@ func logError(err error) {
 	}
 }
 
-var testArgsNewDB = storageUnit.ArgDB{
-	DBType:            "LvlDBSerial",
-	Path:              "path",
-	BatchDelaySeconds: 10,
-	MaxBatchSize:      10,
-	MaxOpenFiles:      10,
-}
-
 func initStorageUnit(tb testing.TB, cSize int) *storageUnit.Unit {
 	mdb := memorydb.New()
 	cache, err2 := lrucache.NewCache(cSize)
 	assert.Nil(tb, err2, "no error expected but got %s", err2)
 
-	sUnit, err := storageUnit.NewStorageUnit(cache, mdb, testArgsNewDB)
+	sUnit, err := storageUnit.NewStorageUnit(cache, mdb)
 	assert.Nil(tb, err, "failed to create storage unit")
 
 	return sUnit
@@ -45,7 +37,7 @@ func TestStorageUnitNilPersister(t *testing.T) {
 
 	assert.Nil(t, err1, "no error expected but got %s", err1)
 
-	_, err := storageUnit.NewStorageUnit(cache, nil, testArgsNewDB)
+	_, err := storageUnit.NewStorageUnit(cache, nil)
 
 	assert.NotNil(t, err, "expected failure")
 }
@@ -53,7 +45,7 @@ func TestStorageUnitNilPersister(t *testing.T) {
 func TestStorageUnitNilCacher(t *testing.T) {
 	mdb := memorydb.New()
 
-	_, err1 := storageUnit.NewStorageUnit(nil, mdb, testArgsNewDB)
+	_, err1 := storageUnit.NewStorageUnit(nil, mdb)
 	assert.NotNil(t, err1, "expected failure")
 }
 
@@ -63,7 +55,7 @@ func TestStorageUnit(t *testing.T) {
 
 	assert.Nil(t, err1, "no error expected but got %s", err1)
 
-	_, err := storageUnit.NewStorageUnit(cache, mdb, testArgsNewDB)
+	_, err := storageUnit.NewStorageUnit(cache, mdb)
 	assert.Nil(t, err, "did not expect failure")
 }
 

--- a/storageUnit/storageunit_test.go
+++ b/storageUnit/storageunit_test.go
@@ -397,7 +397,7 @@ const (
 	valuesInDb = 100000
 )
 
-func TestStorageUnit_ClearStorage(t *testing.T) {
+func TestStorageUnit_Clear(t *testing.T) {
 	storer, err := storageUnit.NewStorageUnitFromConf(storageUnit.CacheConfig{
 		Capacity: 10,
 		Type:     storageUnit.LRUCache,
@@ -418,7 +418,7 @@ func TestStorageUnit_ClearStorage(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, testVal, res)
 
-	err = storer.ClearStorage()
+	err = storer.Clear()
 	require.NoError(t, err)
 
 	res, err = storer.Get(testKey)
@@ -451,7 +451,7 @@ func TestStorageUnit_ConcurrentOperations(t *testing.T) {
 			case 0:
 				storer.ClearCache()
 			case 1:
-				errClearStorage := storer.ClearStorage()
+				errClearStorage := storer.Clear()
 				require.NoError(t, errClearStorage)
 			case 2:
 				errClose := storer.Close()

--- a/testscommon/memDbMock.go
+++ b/testscommon/memDbMock.go
@@ -95,6 +95,16 @@ func (s *MemDbMock) DestroyClosed() error {
 	return nil
 }
 
+// Clear -
+func (s *MemDbMock) Clear() error {
+	s.mutx.Lock()
+	defer s.mutx.Unlock()
+
+	s.db = make(map[string][]byte)
+
+	return nil
+}
+
 // RangeKeys will iterate over all contained (key, value) pairs calling the handler for each pair
 func (s *MemDbMock) RangeKeys(handler func(key []byte, value []byte) bool) {
 	if handler == nil {

--- a/testscommon/persisterStub.go
+++ b/testscommon/persisterStub.go
@@ -6,6 +6,7 @@ type PersisterStub struct {
 	GetCalled           func(key []byte) ([]byte, error)
 	HasCalled           func(key []byte) error
 	CloseCalled         func() error
+	ClearCalled         func() error
 	RemoveCalled        func(key []byte) error
 	DestroyCalled       func() error
 	DestroyClosedCalled func() error
@@ -43,6 +44,15 @@ func (p *PersisterStub) Has(key []byte) error {
 func (p *PersisterStub) Close() error {
 	if p.CloseCalled != nil {
 		return p.CloseCalled()
+	}
+
+	return nil
+}
+
+// Clear -
+func (p *PersisterStub) Clear() error {
+	if p.ClearCalled != nil {
+		return p.ClearCalled()
 	}
 
 	return nil

--- a/types/interface.go
+++ b/types/interface.go
@@ -22,7 +22,10 @@ type Persister interface {
 	Destroy() error
 	// DestroyClosed removes the already closed persistence medium stored data
 	DestroyClosed() error
+	// RangeKeys will call the provided function for all the keys
 	RangeKeys(handler func(key []byte, val []byte) bool)
+	// Clear will clear the data inside the persister
+	Clear() error
 	// IsInterfaceNil returns true if there is no value under the interface
 	IsInterfaceNil() bool
 }
@@ -92,7 +95,7 @@ type Storer interface {
 	RemoveFromCurrentEpoch(key []byte) error
 	Remove(key []byte) error
 	ClearCache()
-	ClearStorage() error
+	Clear() error
 	DestroyUnit() error
 	GetFromEpoch(key []byte, epoch uint32) ([]byte, error)
 	GetBulkFromEpoch(keys [][]byte, epoch uint32) ([]storage.KeyValuePair, error)

--- a/types/interface.go
+++ b/types/interface.go
@@ -92,6 +92,7 @@ type Storer interface {
 	RemoveFromCurrentEpoch(key []byte) error
 	Remove(key []byte) error
 	ClearCache()
+	ClearStorage() error
 	DestroyUnit() error
 	GetFromEpoch(key []byte, epoch uint32) ([]byte, error)
 	GetBulkFromEpoch(keys [][]byte, epoch uint32) ([]storage.KeyValuePair, error)


### PR DESCRIPTION
Added the `ClearStorage() error` function that will destroy a persister and immediately create a new one