### PR TITLE
Mempool: handle not-executable transactions related to guardians

### DIFF
--- a/testscommon/txcachemocks/accountStateProviderMock.go
+++ b/testscommon/txcachemocks/accountStateProviderMock.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"sync"
 
+	"github.com/multiversx/mx-chain-core-go/data"
 	"github.com/multiversx/mx-chain-storage-go/types"
 )
 
@@ -13,6 +14,7 @@ type AccountStateProviderMock struct {
 
 	AccountStateByAddress map[string]*types.AccountState
 	GetAccountStateCalled func(address []byte) (*types.AccountState, error)
+	IsBadlyGuardedCalled  func(tx data.TransactionHandler) bool
 }
 
 // NewAccountStateProviderMock -
@@ -65,6 +67,15 @@ func (mock *AccountStateProviderMock) GetAccountState(address []byte) (*types.Ac
 	}
 
 	return newDefaultAccountState(), nil
+}
+
+// IsBadlyGuarded -
+func (mock *AccountStateProviderMock) IsBadlyGuarded(tx data.TransactionHandler) bool {
+	if mock.IsBadlyGuardedCalled != nil {
+		return mock.IsBadlyGuardedCalled(tx)
+	}
+
+	return false
 }
 
 // IsInterfaceNil -

--- a/testscommon/txcachemocks/selectionSessionMock.go
+++ b/testscommon/txcachemocks/selectionSessionMock.go
@@ -12,9 +12,9 @@ import (
 type SelectionSessionMock struct {
 	mutex sync.Mutex
 
-	AccountStateByAddress map[string]*types.AccountState
-	GetAccountStateCalled func(address []byte) (*types.AccountState, error)
-	IsBadlyGuardedCalled  func(tx data.TransactionHandler) bool
+	AccountStateByAddress      map[string]*types.AccountState
+	GetAccountStateCalled      func(address []byte) (*types.AccountState, error)
+	IsIncorrectlyGuardedCalled func(tx data.TransactionHandler) bool
 }
 
 // NewSelectionSessionMock -
@@ -69,10 +69,10 @@ func (mock *SelectionSessionMock) GetAccountState(address []byte) (*types.Accoun
 	return newDefaultAccountState(), nil
 }
 
-// IsBadlyGuarded -
-func (mock *SelectionSessionMock) IsBadlyGuarded(tx data.TransactionHandler) bool {
-	if mock.IsBadlyGuardedCalled != nil {
-		return mock.IsBadlyGuardedCalled(tx)
+// IsIncorrectlyGuarded -
+func (mock *SelectionSessionMock) IsIncorrectlyGuarded(tx data.TransactionHandler) bool {
+	if mock.IsIncorrectlyGuardedCalled != nil {
+		return mock.IsIncorrectlyGuardedCalled(tx)
 	}
 
 	return false

--- a/testscommon/txcachemocks/selectionSessionMock.go
+++ b/testscommon/txcachemocks/selectionSessionMock.go
@@ -8,8 +8,8 @@ import (
 	"github.com/multiversx/mx-chain-storage-go/types"
 )
 
-// AccountStateProviderMock -
-type AccountStateProviderMock struct {
+// SelectionSessionMock -
+type SelectionSessionMock struct {
 	mutex sync.Mutex
 
 	AccountStateByAddress map[string]*types.AccountState
@@ -17,15 +17,15 @@ type AccountStateProviderMock struct {
 	IsBadlyGuardedCalled  func(tx data.TransactionHandler) bool
 }
 
-// NewAccountStateProviderMock -
-func NewAccountStateProviderMock() *AccountStateProviderMock {
-	return &AccountStateProviderMock{
+// NewSelectionSessionMock -
+func NewSelectionSessionMock() *SelectionSessionMock {
+	return &SelectionSessionMock{
 		AccountStateByAddress: make(map[string]*types.AccountState),
 	}
 }
 
 // SetNonce -
-func (mock *AccountStateProviderMock) SetNonce(address []byte, nonce uint64) {
+func (mock *SelectionSessionMock) SetNonce(address []byte, nonce uint64) {
 	mock.mutex.Lock()
 	defer mock.mutex.Unlock()
 
@@ -39,7 +39,7 @@ func (mock *AccountStateProviderMock) SetNonce(address []byte, nonce uint64) {
 }
 
 // SetBalance -
-func (mock *AccountStateProviderMock) SetBalance(address []byte, balance *big.Int) {
+func (mock *SelectionSessionMock) SetBalance(address []byte, balance *big.Int) {
 	mock.mutex.Lock()
 	defer mock.mutex.Unlock()
 
@@ -53,7 +53,7 @@ func (mock *AccountStateProviderMock) SetBalance(address []byte, balance *big.In
 }
 
 // GetAccountState -
-func (mock *AccountStateProviderMock) GetAccountState(address []byte) (*types.AccountState, error) {
+func (mock *SelectionSessionMock) GetAccountState(address []byte) (*types.AccountState, error) {
 	mock.mutex.Lock()
 	defer mock.mutex.Unlock()
 
@@ -70,7 +70,7 @@ func (mock *AccountStateProviderMock) GetAccountState(address []byte) (*types.Ac
 }
 
 // IsBadlyGuarded -
-func (mock *AccountStateProviderMock) IsBadlyGuarded(tx data.TransactionHandler) bool {
+func (mock *SelectionSessionMock) IsBadlyGuarded(tx data.TransactionHandler) bool {
 	if mock.IsBadlyGuardedCalled != nil {
 		return mock.IsBadlyGuardedCalled(tx)
 	}
@@ -79,7 +79,7 @@ func (mock *AccountStateProviderMock) IsBadlyGuarded(tx data.TransactionHandler)
 }
 
 // IsInterfaceNil -
-func (mock *AccountStateProviderMock) IsInterfaceNil() bool {
+func (mock *SelectionSessionMock) IsInterfaceNil() bool {
 	return mock == nil
 }
 

--- a/txcache/README.md
+++ b/txcache/README.md
@@ -185,7 +185,7 @@ Thus, the mempool selects transactions using an efficient and value-driven algor
  - If a middle nonce gap is detected, the sender is skipped (from now on) in the current selection session.
  - Transactions with nonces lower than the current nonce of the sender are skipped.
  - Transactions having the same nonce as a previously selected one (in the scope of a sender) are skipped. Also see paragraph 5.
- - Badly guarded transactions are skipped.
+ - Incorrectly guarded transactions are skipped.
  - Once the accumulated fees of selected transactions of a given sender exceed the sender's balance, the sender is skipped (from now one).
 
 

--- a/txcache/errors.go
+++ b/txcache/errors.go
@@ -3,6 +3,6 @@ package txcache
 import "errors"
 
 var errNilTxGasHandler = errors.New("nil tx gas handler")
-var errNilAccountStateProvider = errors.New("nil account state provider")
+var errNilSelectionSession = errors.New("nil selection session")
 var errItemAlreadyInCache = errors.New("item already in cache")
 var errEmptyBunchOfTransactions = errors.New("empty bunch of transactions")

--- a/txcache/interface.go
+++ b/txcache/interface.go
@@ -16,6 +16,7 @@ type TxGasHandler interface {
 // AccountStateProvider defines the behavior of a component able to provide the state of an account
 type AccountStateProvider interface {
 	GetAccountState(accountKey []byte) (*types.AccountState, error)
+	IsBadlyGuarded(tx data.TransactionHandler) bool
 	IsInterfaceNil() bool
 }
 

--- a/txcache/interface.go
+++ b/txcache/interface.go
@@ -16,7 +16,7 @@ type TxGasHandler interface {
 // SelectionSession provides blockchain information for transaction selection
 type SelectionSession interface {
 	GetAccountState(accountKey []byte) (*types.AccountState, error)
-	IsBadlyGuarded(tx data.TransactionHandler) bool
+	IsIncorrectlyGuarded(tx data.TransactionHandler) bool
 	IsInterfaceNil() bool
 }
 

--- a/txcache/interface.go
+++ b/txcache/interface.go
@@ -13,8 +13,8 @@ type TxGasHandler interface {
 	IsInterfaceNil() bool
 }
 
-// AccountStateProvider defines the behavior of a component able to provide the state of an account
-type AccountStateProvider interface {
+// SelectionSession provides blockchain information for transaction selection
+type SelectionSession interface {
 	GetAccountState(accountKey []byte) (*types.AccountState, error)
 	IsBadlyGuarded(tx data.TransactionHandler) bool
 	IsInterfaceNil() bool

--- a/txcache/selection.go
+++ b/txcache/selection.go
@@ -71,7 +71,7 @@ func selectTransactionsFromBunches(accountStateProvider AccountStateProvider, bu
 			continue
 		}
 
-		shouldSkipTransaction := detectSkippableTransaction(item)
+		shouldSkipTransaction := detectSkippableTransaction(accountStateProvider, item)
 		if shouldSkipTransaction {
 			// Transaction isn't selected, but the sender is still in the game (will contribute with other transactions).
 		} else {
@@ -104,11 +104,11 @@ func detectSkippableSender(item *transactionsHeapItem) bool {
 	return false
 }
 
-func detectSkippableTransaction(item *transactionsHeapItem) bool {
+func detectSkippableTransaction(accountStateProvider AccountStateProvider, item *transactionsHeapItem) bool {
 	if item.detectLowerNonce() {
 		return true
 	}
-	if item.detectBadlyGuarded() {
+	if item.detectBadlyGuarded(accountStateProvider) {
 		return true
 	}
 	if item.detectNonceDuplicate() {

--- a/txcache/selection.go
+++ b/txcache/selection.go
@@ -112,7 +112,7 @@ func detectSkippableTransaction(session SelectionSession, item *transactionsHeap
 	if item.detectLowerNonce() {
 		return true
 	}
-	if item.detectBadlyGuarded(session) {
+	if item.detectIncorrectlyGuarded(session) {
 		return true
 	}
 	if item.detectNonceDuplicate() {

--- a/txcache/selection_test.go
+++ b/txcache/selection_test.go
@@ -15,10 +15,10 @@ import (
 func TestTxCache_SelectTransactions_Dummy(t *testing.T) {
 	t.Run("all having same PPU", func(t *testing.T) {
 		cache := newUnconstrainedCacheToTest()
-		accountStateProvider := txcachemocks.NewAccountStateProviderMock()
-		accountStateProvider.SetNonce([]byte("alice"), 1)
-		accountStateProvider.SetNonce([]byte("bob"), 5)
-		accountStateProvider.SetNonce([]byte("carol"), 1)
+		session := txcachemocks.NewSelectionSessionMock()
+		session.SetNonce([]byte("alice"), 1)
+		session.SetNonce([]byte("bob"), 5)
+		session.SetNonce([]byte("carol"), 1)
 
 		cache.AddTx(createTx([]byte("hash-alice-4"), "alice", 4))
 		cache.AddTx(createTx([]byte("hash-alice-3"), "alice", 3))
@@ -29,7 +29,7 @@ func TestTxCache_SelectTransactions_Dummy(t *testing.T) {
 		cache.AddTx(createTx([]byte("hash-bob-5"), "bob", 5))
 		cache.AddTx(createTx([]byte("hash-carol-1"), "carol", 1))
 
-		selected, accumulatedGas := cache.SelectTransactions(accountStateProvider, math.MaxUint64, math.MaxInt, selectionLoopMaximumDuration)
+		selected, accumulatedGas := cache.SelectTransactions(session, math.MaxUint64, math.MaxInt, selectionLoopMaximumDuration)
 		require.Len(t, selected, 8)
 		require.Equal(t, 400000, int(accumulatedGas))
 
@@ -46,16 +46,16 @@ func TestTxCache_SelectTransactions_Dummy(t *testing.T) {
 
 	t.Run("alice > carol > bob", func(t *testing.T) {
 		cache := newUnconstrainedCacheToTest()
-		accountStateProvider := txcachemocks.NewAccountStateProviderMock()
-		accountStateProvider.SetNonce([]byte("alice"), 1)
-		accountStateProvider.SetNonce([]byte("bob"), 5)
-		accountStateProvider.SetNonce([]byte("carol"), 3)
+		session := txcachemocks.NewSelectionSessionMock()
+		session.SetNonce([]byte("alice"), 1)
+		session.SetNonce([]byte("bob"), 5)
+		session.SetNonce([]byte("carol"), 3)
 
 		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1).withGasPrice(100))
 		cache.AddTx(createTx([]byte("hash-bob-5"), "bob", 5).withGasPrice(50))
 		cache.AddTx(createTx([]byte("hash-carol-3"), "carol", 3).withGasPrice(75))
 
-		selected, accumulatedGas := cache.SelectTransactions(accountStateProvider, math.MaxUint64, math.MaxInt, selectionLoopMaximumDuration)
+		selected, accumulatedGas := cache.SelectTransactions(session, math.MaxUint64, math.MaxInt, selectionLoopMaximumDuration)
 		require.Len(t, selected, 3)
 		require.Equal(t, 150000, int(accumulatedGas))
 
@@ -69,10 +69,10 @@ func TestTxCache_SelectTransactions_Dummy(t *testing.T) {
 func TestTxCache_SelectTransactionsWithBandwidth_Dummy(t *testing.T) {
 	t.Run("transactions with no data field", func(t *testing.T) {
 		cache := newUnconstrainedCacheToTest()
-		accountStateProvider := txcachemocks.NewAccountStateProviderMock()
-		accountStateProvider.SetNonce([]byte("alice"), 1)
-		accountStateProvider.SetNonce([]byte("bob"), 5)
-		accountStateProvider.SetNonce([]byte("carol"), 1)
+		session := txcachemocks.NewSelectionSessionMock()
+		session.SetNonce([]byte("alice"), 1)
+		session.SetNonce([]byte("bob"), 5)
+		session.SetNonce([]byte("carol"), 1)
 
 		cache.AddTx(createTx([]byte("hash-alice-4"), "alice", 4).withGasLimit(100000))
 		cache.AddTx(createTx([]byte("hash-alice-3"), "alice", 3).withGasLimit(100000))
@@ -83,7 +83,7 @@ func TestTxCache_SelectTransactionsWithBandwidth_Dummy(t *testing.T) {
 		cache.AddTx(createTx([]byte("hash-bob-5"), "bob", 5).withGasLimit(50000))
 		cache.AddTx(createTx([]byte("hash-carol-1"), "carol", 1).withGasLimit(50000))
 
-		selected, accumulatedGas := cache.SelectTransactions(accountStateProvider, 760000, math.MaxInt, selectionLoopMaximumDuration)
+		selected, accumulatedGas := cache.SelectTransactions(session, 760000, math.MaxInt, selectionLoopMaximumDuration)
 		require.Len(t, selected, 5)
 		require.Equal(t, 750000, int(accumulatedGas))
 
@@ -99,10 +99,10 @@ func TestTxCache_SelectTransactionsWithBandwidth_Dummy(t *testing.T) {
 func TestTxCache_SelectTransactions_HandlesNotExecutableTransactions(t *testing.T) {
 	t.Run("with middle gaps", func(t *testing.T) {
 		cache := newUnconstrainedCacheToTest()
-		accountStateProvider := txcachemocks.NewAccountStateProviderMock()
-		accountStateProvider.SetNonce([]byte("alice"), 1)
-		accountStateProvider.SetNonce([]byte("bob"), 42)
-		accountStateProvider.SetNonce([]byte("carol"), 7)
+		session := txcachemocks.NewSelectionSessionMock()
+		session.SetNonce([]byte("alice"), 1)
+		session.SetNonce([]byte("bob"), 42)
+		session.SetNonce([]byte("carol"), 7)
 
 		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1))
 		cache.AddTx(createTx([]byte("hash-alice-2"), "alice", 2))
@@ -116,7 +116,7 @@ func TestTxCache_SelectTransactions_HandlesNotExecutableTransactions(t *testing.
 		cache.AddTx(createTx([]byte("hash-carol-10"), "carol", 10)) // gap
 		cache.AddTx(createTx([]byte("hash-carol-11"), "carol", 11))
 
-		sorted, accumulatedGas := cache.SelectTransactions(accountStateProvider, math.MaxUint64, math.MaxInt, selectionLoopMaximumDuration)
+		sorted, accumulatedGas := cache.SelectTransactions(session, math.MaxUint64, math.MaxInt, selectionLoopMaximumDuration)
 		expectedNumSelected := 3 + 1 + 2 // 3 alice + 1 bob + 2 carol
 		require.Len(t, sorted, expectedNumSelected)
 		require.Equal(t, 300000, int(accumulatedGas))
@@ -124,10 +124,10 @@ func TestTxCache_SelectTransactions_HandlesNotExecutableTransactions(t *testing.
 
 	t.Run("with initial gaps", func(t *testing.T) {
 		cache := newUnconstrainedCacheToTest()
-		accountStateProvider := txcachemocks.NewAccountStateProviderMock()
-		accountStateProvider.SetNonce([]byte("alice"), 1)
-		accountStateProvider.SetNonce([]byte("bob"), 42)
-		accountStateProvider.SetNonce([]byte("carol"), 7)
+		session := txcachemocks.NewSelectionSessionMock()
+		session.SetNonce([]byte("alice"), 1)
+		session.SetNonce([]byte("bob"), 42)
+		session.SetNonce([]byte("carol"), 7)
 
 		// Good
 		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1))
@@ -143,7 +143,7 @@ func TestTxCache_SelectTransactions_HandlesNotExecutableTransactions(t *testing.
 		cache.AddTx(createTx([]byte("hash-carol-7"), "carol", 7))
 		cache.AddTx(createTx([]byte("hash-carol-8"), "carol", 8))
 
-		sorted, accumulatedGas := cache.SelectTransactions(accountStateProvider, math.MaxUint64, math.MaxInt, selectionLoopMaximumDuration)
+		sorted, accumulatedGas := cache.SelectTransactions(session, math.MaxUint64, math.MaxInt, selectionLoopMaximumDuration)
 		expectedNumSelected := 3 + 0 + 2 // 3 alice + 0 bob + 2 carol
 		require.Len(t, sorted, expectedNumSelected)
 		require.Equal(t, 250000, int(accumulatedGas))
@@ -151,10 +151,10 @@ func TestTxCache_SelectTransactions_HandlesNotExecutableTransactions(t *testing.
 
 	t.Run("with lower nonces", func(t *testing.T) {
 		cache := newUnconstrainedCacheToTest()
-		accountStateProvider := txcachemocks.NewAccountStateProviderMock()
-		accountStateProvider.SetNonce([]byte("alice"), 1)
-		accountStateProvider.SetNonce([]byte("bob"), 42)
-		accountStateProvider.SetNonce([]byte("carol"), 7)
+		session := txcachemocks.NewSelectionSessionMock()
+		session.SetNonce([]byte("alice"), 1)
+		session.SetNonce([]byte("bob"), 42)
+		session.SetNonce([]byte("carol"), 7)
 
 		// Good
 		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1))
@@ -170,7 +170,7 @@ func TestTxCache_SelectTransactions_HandlesNotExecutableTransactions(t *testing.
 		cache.AddTx(createTx([]byte("hash-carol-7"), "carol", 7))
 		cache.AddTx(createTx([]byte("hash-carol-8"), "carol", 8))
 
-		sorted, accumulatedGas := cache.SelectTransactions(accountStateProvider, math.MaxUint64, math.MaxInt, selectionLoopMaximumDuration)
+		sorted, accumulatedGas := cache.SelectTransactions(session, math.MaxUint64, math.MaxInt, selectionLoopMaximumDuration)
 		expectedNumSelected := 3 + 1 + 2 // 3 alice + 1 bob + 2 carol
 		require.Len(t, sorted, expectedNumSelected)
 		require.Equal(t, 300000, int(accumulatedGas))
@@ -178,8 +178,8 @@ func TestTxCache_SelectTransactions_HandlesNotExecutableTransactions(t *testing.
 
 	t.Run("with duplicated nonces", func(t *testing.T) {
 		cache := newUnconstrainedCacheToTest()
-		accountStateProvider := txcachemocks.NewAccountStateProviderMock()
-		accountStateProvider.SetNonce([]byte("alice"), 1)
+		session := txcachemocks.NewSelectionSessionMock()
+		session.SetNonce([]byte("alice"), 1)
 
 		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1))
 		cache.AddTx(createTx([]byte("hash-alice-2"), "alice", 2))
@@ -188,7 +188,7 @@ func TestTxCache_SelectTransactions_HandlesNotExecutableTransactions(t *testing.
 		cache.AddTx(createTx([]byte("hash-alice-3c"), "alice", 3))
 		cache.AddTx(createTx([]byte("hash-alice-4"), "alice", 4))
 
-		sorted, accumulatedGas := cache.SelectTransactions(accountStateProvider, math.MaxUint64, math.MaxInt, selectionLoopMaximumDuration)
+		sorted, accumulatedGas := cache.SelectTransactions(session, math.MaxUint64, math.MaxInt, selectionLoopMaximumDuration)
 		require.Len(t, sorted, 4)
 		require.Equal(t, 200000, int(accumulatedGas))
 
@@ -200,11 +200,11 @@ func TestTxCache_SelectTransactions_HandlesNotExecutableTransactions(t *testing.
 
 	t.Run("with fee exceeding balance", func(t *testing.T) {
 		cache := newUnconstrainedCacheToTest()
-		accountStateProvider := txcachemocks.NewAccountStateProviderMock()
-		accountStateProvider.SetNonce([]byte("alice"), 1)
-		accountStateProvider.SetBalance([]byte("alice"), big.NewInt(150000000000000))
-		accountStateProvider.SetNonce([]byte("bob"), 42)
-		accountStateProvider.SetBalance([]byte("bob"), big.NewInt(70000000000000))
+		session := txcachemocks.NewSelectionSessionMock()
+		session.SetNonce([]byte("alice"), 1)
+		session.SetBalance([]byte("alice"), big.NewInt(150000000000000))
+		session.SetNonce([]byte("bob"), 42)
+		session.SetBalance([]byte("bob"), big.NewInt(70000000000000))
 
 		// Enough balance
 		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1))
@@ -216,7 +216,7 @@ func TestTxCache_SelectTransactions_HandlesNotExecutableTransactions(t *testing.
 		cache.AddTx(createTx([]byte("hash-bob-43"), "bob", 41))
 		cache.AddTx(createTx([]byte("hash-bob-44"), "bob", 42))
 
-		sorted, accumulatedGas := cache.SelectTransactions(accountStateProvider, math.MaxUint64, math.MaxInt, selectionLoopMaximumDuration)
+		sorted, accumulatedGas := cache.SelectTransactions(session, math.MaxUint64, math.MaxInt, selectionLoopMaximumDuration)
 		expectedNumSelected := 3 + 1 // 3 alice + 1 bob
 		require.Len(t, sorted, expectedNumSelected)
 		require.Equal(t, 200000, int(accumulatedGas))
@@ -225,7 +225,7 @@ func TestTxCache_SelectTransactions_HandlesNotExecutableTransactions(t *testing.
 
 func TestTxCache_SelectTransactions_WhenTransactionsAddedInReversedNonceOrder(t *testing.T) {
 	cache := newUnconstrainedCacheToTest()
-	accountStateProvider := txcachemocks.NewAccountStateProviderMock()
+	session := txcachemocks.NewSelectionSessionMock()
 
 	// Add "nSenders" * "nTransactionsPerSender" transactions in the cache (in reversed nonce order)
 	nSenders := 1000
@@ -244,7 +244,7 @@ func TestTxCache_SelectTransactions_WhenTransactionsAddedInReversedNonceOrder(t 
 
 	require.Equal(t, uint64(nTotalTransactions), cache.CountTx())
 
-	sorted, accumulatedGas := cache.SelectTransactions(accountStateProvider, math.MaxUint64, math.MaxInt, selectionLoopMaximumDuration)
+	sorted, accumulatedGas := cache.SelectTransactions(session, math.MaxUint64, math.MaxInt, selectionLoopMaximumDuration)
 	require.Len(t, sorted, nTotalTransactions)
 	require.Equal(t, 5_000_000_000, int(accumulatedGas))
 
@@ -263,8 +263,8 @@ func TestTxCache_SelectTransactions_WhenTransactionsAddedInReversedNonceOrder(t 
 
 func TestTxCache_selectTransactionsFromBunches(t *testing.T) {
 	t.Run("empty cache", func(t *testing.T) {
-		accountStateProvider := txcachemocks.NewAccountStateProviderMock()
-		selected, accumulatedGas := selectTransactionsFromBunches(accountStateProvider, []bunchOfTransactions{}, 10_000_000_000, math.MaxInt, selectionLoopMaximumDuration)
+		session := txcachemocks.NewSelectionSessionMock()
+		selected, accumulatedGas := selectTransactionsFromBunches(session, []bunchOfTransactions{}, 10_000_000_000, math.MaxInt, selectionLoopMaximumDuration)
 
 		require.Equal(t, 0, len(selected))
 		require.Equal(t, uint64(0), accumulatedGas)
@@ -275,11 +275,11 @@ func TestBenchmarkTxCache_selectTransactionsFromBunches(t *testing.T) {
 	sw := core.NewStopWatch()
 
 	t.Run("numSenders = 1000, numTransactions = 1000", func(t *testing.T) {
-		accountStateProvider := txcachemocks.NewAccountStateProviderMock()
+		session := txcachemocks.NewSelectionSessionMock()
 		bunches := createBunchesOfTransactionsWithUniformDistribution(1000, 1000)
 
 		sw.Start(t.Name())
-		selected, accumulatedGas := selectTransactionsFromBunches(accountStateProvider, bunches, 10_000_000_000, math.MaxInt, selectionLoopMaximumDuration)
+		selected, accumulatedGas := selectTransactionsFromBunches(session, bunches, 10_000_000_000, math.MaxInt, selectionLoopMaximumDuration)
 		sw.Stop(t.Name())
 
 		require.Equal(t, 200000, len(selected))
@@ -287,11 +287,11 @@ func TestBenchmarkTxCache_selectTransactionsFromBunches(t *testing.T) {
 	})
 
 	t.Run("numSenders = 10000, numTransactions = 100", func(t *testing.T) {
-		accountStateProvider := txcachemocks.NewAccountStateProviderMock()
+		session := txcachemocks.NewSelectionSessionMock()
 		bunches := createBunchesOfTransactionsWithUniformDistribution(1000, 1000)
 
 		sw.Start(t.Name())
-		selected, accumulatedGas := selectTransactionsFromBunches(accountStateProvider, bunches, 10_000_000_000, math.MaxInt, selectionLoopMaximumDuration)
+		selected, accumulatedGas := selectTransactionsFromBunches(session, bunches, 10_000_000_000, math.MaxInt, selectionLoopMaximumDuration)
 		sw.Stop(t.Name())
 
 		require.Equal(t, 200000, len(selected))
@@ -299,11 +299,11 @@ func TestBenchmarkTxCache_selectTransactionsFromBunches(t *testing.T) {
 	})
 
 	t.Run("numSenders = 100000, numTransactions = 3", func(t *testing.T) {
-		accountStateProvider := txcachemocks.NewAccountStateProviderMock()
+		session := txcachemocks.NewSelectionSessionMock()
 		bunches := createBunchesOfTransactionsWithUniformDistribution(100000, 3)
 
 		sw.Start(t.Name())
-		selected, accumulatedGas := selectTransactionsFromBunches(accountStateProvider, bunches, 10_000_000_000, math.MaxInt, selectionLoopMaximumDuration)
+		selected, accumulatedGas := selectTransactionsFromBunches(session, bunches, 10_000_000_000, math.MaxInt, selectionLoopMaximumDuration)
 		sw.Stop(t.Name())
 
 		require.Equal(t, 200000, len(selected))
@@ -311,11 +311,11 @@ func TestBenchmarkTxCache_selectTransactionsFromBunches(t *testing.T) {
 	})
 
 	t.Run("numSenders = 300000, numTransactions = 1", func(t *testing.T) {
-		accountStateProvider := txcachemocks.NewAccountStateProviderMock()
+		session := txcachemocks.NewSelectionSessionMock()
 		bunches := createBunchesOfTransactionsWithUniformDistribution(300000, 1)
 
 		sw.Start(t.Name())
-		selected, accumulatedGas := selectTransactionsFromBunches(accountStateProvider, bunches, 10_000_000_000, math.MaxInt, selectionLoopMaximumDuration)
+		selected, accumulatedGas := selectTransactionsFromBunches(session, bunches, 10_000_000_000, math.MaxInt, selectionLoopMaximumDuration)
 		sw.Stop(t.Name())
 
 		require.Equal(t, 200000, len(selected))
@@ -342,9 +342,9 @@ func TestBenchmarkTxCache_selectTransactionsFromBunches(t *testing.T) {
 
 func TestTxCache_selectTransactionsFromBunches_loopBreaks_whenTakesTooLong(t *testing.T) {
 	t.Run("numSenders = 300000, numTransactions = 1", func(t *testing.T) {
-		accountStateProvider := txcachemocks.NewAccountStateProviderMock()
+		session := txcachemocks.NewSelectionSessionMock()
 		bunches := createBunchesOfTransactionsWithUniformDistribution(300000, 1)
-		selected, accumulatedGas := selectTransactionsFromBunches(accountStateProvider, bunches, 10_000_000_000, 50_000, 1*time.Millisecond)
+		selected, accumulatedGas := selectTransactionsFromBunches(session, bunches, 10_000_000_000, 50_000, 1*time.Millisecond)
 
 		require.Less(t, len(selected), 50_000)
 		require.Less(t, int(accumulatedGas), 10_000_000_000)
@@ -364,7 +364,7 @@ func TestBenchmarkTxCache_doSelectTransactions(t *testing.T) {
 	}
 
 	txGasHandler := txcachemocks.NewTxGasHandlerMock()
-	accountStateProvider := txcachemocks.NewAccountStateProviderMock()
+	session := txcachemocks.NewSelectionSessionMock()
 
 	sw := core.NewStopWatch()
 
@@ -377,7 +377,7 @@ func TestBenchmarkTxCache_doSelectTransactions(t *testing.T) {
 		require.Equal(t, 100000, int(cache.CountTx()))
 
 		sw.Start(t.Name())
-		selected, accumulatedGas := cache.SelectTransactions(accountStateProvider, 10_000_000_000, 50_000, selectionLoopMaximumDuration)
+		selected, accumulatedGas := cache.SelectTransactions(session, 10_000_000_000, 50_000, selectionLoopMaximumDuration)
 		sw.Stop(t.Name())
 
 		require.Equal(t, 50000, len(selected))
@@ -393,7 +393,7 @@ func TestBenchmarkTxCache_doSelectTransactions(t *testing.T) {
 		require.Equal(t, 100000, int(cache.CountTx()))
 
 		sw.Start(t.Name())
-		selected, accumulatedGas := cache.SelectTransactions(accountStateProvider, 10_000_000_000, 50_000, selectionLoopMaximumDuration)
+		selected, accumulatedGas := cache.SelectTransactions(session, 10_000_000_000, 50_000, selectionLoopMaximumDuration)
 		sw.Stop(t.Name())
 
 		require.Equal(t, 50000, len(selected))
@@ -409,7 +409,7 @@ func TestBenchmarkTxCache_doSelectTransactions(t *testing.T) {
 		require.Equal(t, 300000, int(cache.CountTx()))
 
 		sw.Start(t.Name())
-		selected, accumulatedGas := cache.SelectTransactions(accountStateProvider, 10_000_000_000, 50_000, selectionLoopMaximumDuration)
+		selected, accumulatedGas := cache.SelectTransactions(session, 10_000_000_000, 50_000, selectionLoopMaximumDuration)
 		sw.Stop(t.Name())
 
 		require.Equal(t, 50000, len(selected))

--- a/txcache/selection_test.go
+++ b/txcache/selection_test.go
@@ -509,7 +509,7 @@ func TestBenchmarkTxCache_doSelectTransactions(t *testing.T) {
 		require.Equal(t, 1000000, int(cache.CountTx()))
 
 		sw.Start(t.Name())
-		selected, accumulatedGas := cache.SelectTransactions(accountStateProvider, 10_000_000_000, 50_000, selectionLoopMaximumDuration)
+		selected, accumulatedGas := cache.SelectTransactions(session, 10_000_000_000, 50_000, selectionLoopMaximumDuration)
 		sw.Stop(t.Name())
 
 		require.Equal(t, 50000, len(selected))

--- a/txcache/selection_test.go
+++ b/txcache/selection_test.go
@@ -224,18 +224,14 @@ func TestTxCache_SelectTransactions_HandlesNotExecutableTransactions(t *testing.
 		require.Equal(t, 200000, int(accumulatedGas))
 	})
 
-	t.Run("with badly guarded", func(t *testing.T) {
+	t.Run("with incorrectly guarded", func(t *testing.T) {
 		cache := newUnconstrainedCacheToTest()
 		session := txcachemocks.NewSelectionSessionMock()
 		session.SetNonce([]byte("alice"), 1)
 		session.SetNonce([]byte("bob"), 42)
 
-		session.IsBadlyGuardedCalled = func(tx data.TransactionHandler) bool {
-			if bytes.Equal(tx.GetData(), []byte("t")) {
-				return true
-			}
-
-			return false
+		session.IsIncorrectlyGuardedCalled = func(tx data.TransactionHandler) bool {
+			return bytes.Equal(tx.GetData(), []byte("t"))
 		}
 
 		cache.AddTx(createTx([]byte("hash-alice-1"), "alice", 1).withData([]byte("x")).withGasLimit(100000))

--- a/txcache/testutils_test.go
+++ b/txcache/testutils_test.go
@@ -155,6 +155,13 @@ func (wrappedTx *WrappedTransaction) withSize(size uint64) *WrappedTransaction {
 	return wrappedTx
 }
 
+func (wrappedTx *WrappedTransaction) withData(data []byte) *WrappedTransaction {
+	tx := wrappedTx.Tx.(*transaction.Transaction)
+	tx.Data = data
+	wrappedTx.Size = int64(len(data)) + int64(estimatedSizeOfBoundedTxFields)
+	return wrappedTx
+}
+
 func (wrappedTx *WrappedTransaction) withDataLength(dataLength int) *WrappedTransaction {
 	tx := wrappedTx.Tx.(*transaction.Transaction)
 	tx.Data = make([]byte, dataLength)

--- a/txcache/testutils_test.go
+++ b/txcache/testutils_test.go
@@ -174,12 +174,6 @@ func (wrappedTx *WrappedTransaction) withGasLimit(gasLimit uint64) *WrappedTrans
 	return wrappedTx
 }
 
-func (wrappedTx *WrappedTransaction) withGuardian(guardian []byte) *WrappedTransaction {
-	tx := wrappedTx.Tx.(*transaction.Transaction)
-	tx.GuardianAddr = guardian
-	return wrappedTx
-}
-
 func createFakeSenderAddress(senderTag int) []byte {
 	bytes := make([]byte, 32)
 	binary.LittleEndian.PutUint64(bytes, uint64(senderTag))

--- a/txcache/transactionsHeapItem.go
+++ b/txcache/transactionsHeapItem.go
@@ -157,8 +157,8 @@ func (item *transactionsHeapItem) detectLowerNonce() bool {
 	return isLowerNonce
 }
 
-func (item *transactionsHeapItem) detectBadlyGuarded(accountStateProvider AccountStateProvider) bool {
-	isBadlyGuarded := accountStateProvider.IsBadlyGuarded(item.currentTransaction.Tx)
+func (item *transactionsHeapItem) detectBadlyGuarded(session SelectionSession) bool {
+	isBadlyGuarded := session.IsBadlyGuarded(item.currentTransaction.Tx)
 	if isBadlyGuarded {
 		logSelect.Trace("transactionsHeapItem.detectBadlyGuarded",
 			"tx", item.currentTransaction.TxHash,
@@ -186,12 +186,12 @@ func (item *transactionsHeapItem) detectNonceDuplicate() bool {
 	return isDuplicate
 }
 
-func (item *transactionsHeapItem) requestAccountStateIfNecessary(accountStateProvider AccountStateProvider) error {
+func (item *transactionsHeapItem) requestAccountStateIfNecessary(session SelectionSession) error {
 	if item.senderState != nil {
 		return nil
 	}
 
-	senderState, err := accountStateProvider.GetAccountState(item.sender)
+	senderState, err := session.GetAccountState(item.sender)
 	if err != nil {
 		return err
 	}

--- a/txcache/transactionsHeapItem.go
+++ b/txcache/transactionsHeapItem.go
@@ -157,16 +157,16 @@ func (item *transactionsHeapItem) detectLowerNonce() bool {
 	return isLowerNonce
 }
 
-func (item *transactionsHeapItem) detectBadlyGuarded(session SelectionSession) bool {
-	isBadlyGuarded := session.IsBadlyGuarded(item.currentTransaction.Tx)
-	if isBadlyGuarded {
-		logSelect.Trace("transactionsHeapItem.detectBadlyGuarded",
+func (item *transactionsHeapItem) detectIncorrectlyGuarded(session SelectionSession) bool {
+	IsIncorrectlyGuarded := session.IsIncorrectlyGuarded(item.currentTransaction.Tx)
+	if IsIncorrectlyGuarded {
+		logSelect.Trace("transactionsHeapItem.detectIncorrectlyGuarded",
 			"tx", item.currentTransaction.TxHash,
 			"sender", item.sender,
 		)
 	}
 
-	return isBadlyGuarded
+	return IsIncorrectlyGuarded
 }
 
 func (item *transactionsHeapItem) detectNonceDuplicate() bool {

--- a/txcache/transactionsHeapItem.go
+++ b/txcache/transactionsHeapItem.go
@@ -157,9 +157,16 @@ func (item *transactionsHeapItem) detectLowerNonce() bool {
 	return isLowerNonce
 }
 
-func (item *transactionsHeapItem) detectBadlyGuarded() bool {
-	// See MX-16179.
-	return false
+func (item *transactionsHeapItem) detectBadlyGuarded(accountStateProvider AccountStateProvider) bool {
+	isBadlyGuarded := accountStateProvider.IsBadlyGuarded(item.currentTransaction.Tx)
+	if isBadlyGuarded {
+		logSelect.Trace("transactionsHeapItem.detectBadlyGuarded",
+			"tx", item.currentTransaction.TxHash,
+			"sender", item.sender,
+		)
+	}
+
+	return isBadlyGuarded
 }
 
 func (item *transactionsHeapItem) detectNonceDuplicate() bool {

--- a/txcache/transactionsHeapItem_test.go
+++ b/txcache/transactionsHeapItem_test.go
@@ -232,29 +232,29 @@ func TestTransactionsHeapItem_detectNonceDuplicate(t *testing.T) {
 	})
 }
 
-func TestTransactionsHeapItem_detectBadlyGuarded(t *testing.T) {
-	t.Run("is not badly guarded", func(t *testing.T) {
+func TestTransactionsHeapItem_detectIncorrectlyGuarded(t *testing.T) {
+	t.Run("is correctly guarded", func(t *testing.T) {
 		session := txcachemocks.NewSelectionSessionMock()
-		session.IsBadlyGuardedCalled = func(tx data.TransactionHandler) bool {
+		session.IsIncorrectlyGuardedCalled = func(tx data.TransactionHandler) bool {
 			return false
 		}
 
 		item, err := newTransactionsHeapItem(bunchOfTransactions{createTx([]byte("tx-1"), "alice", 42)})
 		require.NoError(t, err)
 
-		require.False(t, item.detectBadlyGuarded(session))
+		require.False(t, item.detectIncorrectlyGuarded(session))
 	})
 
-	t.Run("is badly guarded", func(t *testing.T) {
+	t.Run("is incorrectly guarded", func(t *testing.T) {
 		session := txcachemocks.NewSelectionSessionMock()
-		session.IsBadlyGuardedCalled = func(tx data.TransactionHandler) bool {
+		session.IsIncorrectlyGuardedCalled = func(tx data.TransactionHandler) bool {
 			return true
 		}
 
 		item, err := newTransactionsHeapItem(bunchOfTransactions{createTx([]byte("tx-1"), "alice", 42)})
 		require.NoError(t, err)
 
-		require.True(t, item.detectBadlyGuarded(session))
+		require.True(t, item.detectIncorrectlyGuarded(session))
 	})
 }
 

--- a/txcache/txCache.go
+++ b/txcache/txCache.go
@@ -99,9 +99,9 @@ func (cache *TxCache) GetByTxHash(txHash []byte) (*WrappedTransaction, bool) {
 
 // SelectTransactions selects the best transactions to be included in the next miniblock.
 // It returns up to "maxNum" transactions, with total gas <= "gasRequested".
-func (cache *TxCache) SelectTransactions(accountStateProvider AccountStateProvider, gasRequested uint64, maxNum int, selectionLoopMaximumDuration time.Duration) ([]*WrappedTransaction, uint64) {
-	if check.IfNil(accountStateProvider) {
-		log.Error("TxCache.SelectTransactions", "err", errNilAccountStateProvider)
+func (cache *TxCache) SelectTransactions(session SelectionSession, gasRequested uint64, maxNum int, selectionLoopMaximumDuration time.Duration) ([]*WrappedTransaction, uint64) {
+	if check.IfNil(session) {
+		log.Error("TxCache.SelectTransactions", "err", errNilSelectionSession)
 		return nil, 0
 	}
 
@@ -115,7 +115,7 @@ func (cache *TxCache) SelectTransactions(accountStateProvider AccountStateProvid
 		"num senders", cache.CountSenders(),
 	)
 
-	transactions, accumulatedGas := cache.doSelectTransactions(accountStateProvider, gasRequested, maxNum, selectionLoopMaximumDuration)
+	transactions, accumulatedGas := cache.doSelectTransactions(session, gasRequested, maxNum, selectionLoopMaximumDuration)
 
 	stopWatch.Stop("selection")
 

--- a/txcache/wrappedTransaction_test.go
+++ b/txcache/wrappedTransaction_test.go
@@ -37,7 +37,7 @@ func TestWrappedTransaction_precomputeFields(t *testing.T) {
 	})
 
 	t.Run("with guardian", func(t *testing.T) {
-		tx := createTx([]byte("a"), "a", 1).withGuardian([]byte("heidi"))
+		tx := createTx([]byte("a"), "a", 1)
 		tx.precomputeFields(txGasHandler)
 
 		require.Equal(t, "50000000000000", tx.Fee.String())


### PR DESCRIPTION
Make sure we don't select not-executable transactions (at all). Here, we handle transactions related to guardians.

The _AccountStateProvider_ has been renamed to _SelectionSession_. It has a new function: `IsBadlyGuarded`, called during selection.

Integration PR:
 - https://github.com/multiversx/mx-chain-go/pull/6628