### PR TITLE
Handle consumed balance

### DIFF
--- a/testscommon/txcachemocks/selectionSessionMock.go
+++ b/testscommon/txcachemocks/selectionSessionMock.go
@@ -12,9 +12,10 @@ import (
 type SelectionSessionMock struct {
 	mutex sync.Mutex
 
-	AccountStateByAddress map[string]*types.AccountState
-	GetAccountStateCalled func(address []byte) (*types.AccountState, error)
-	IsBadlyGuardedCalled  func(tx data.TransactionHandler) bool
+	AccountStateByAddress     map[string]*types.AccountState
+	GetAccountStateCalled     func(address []byte) (*types.AccountState, error)
+	IsBadlyGuardedCalled      func(tx data.TransactionHandler) bool
+	GetTransferredValueCalled func(tx data.TransactionHandler) *big.Int
 }
 
 // NewSelectionSessionMock -
@@ -76,6 +77,15 @@ func (mock *SelectionSessionMock) IsBadlyGuarded(tx data.TransactionHandler) boo
 	}
 
 	return false
+}
+
+// GetTransferredValue -
+func (mock *SelectionSessionMock) GetTransferredValue(tx data.TransactionHandler) *big.Int {
+	if mock.GetTransferredValueCalled != nil {
+		return mock.GetTransferredValueCalled(tx)
+	}
+
+	return tx.GetValue()
 }
 
 // IsInterfaceNil -

--- a/txcache/diagnosis.go
+++ b/txcache/diagnosis.go
@@ -73,7 +73,7 @@ func (cache *TxCache) diagnoseTransactions() {
 }
 
 // marshalTransactionsToNewlineDelimitedJSON converts a list of transactions to a newline-delimited JSON string.
-// Note: each line is indexed, to improve readability. The index is easily removable for if separate analysis is needed.
+// Note: each line is indexed, to improve readability. The index is easily removable for separate analysis is needed.
 func marshalTransactionsToNewlineDelimitedJSON(transactions []*WrappedTransaction, linePrefix string) string {
 	builder := strings.Builder{}
 	builder.WriteString("\n")

--- a/txcache/interface.go
+++ b/txcache/interface.go
@@ -17,6 +17,7 @@ type TxGasHandler interface {
 type SelectionSession interface {
 	GetAccountState(accountKey []byte) (*types.AccountState, error)
 	IsBadlyGuarded(tx data.TransactionHandler) bool
+	GetTransferredValue(tx data.TransactionHandler) *big.Int
 	IsInterfaceNil() bool
 }
 

--- a/txcache/selection.go
+++ b/txcache/selection.go
@@ -76,7 +76,7 @@ func selectTransactionsFromBunches(session SelectionSession, bunches []bunchOfTr
 			// Transaction isn't selected, but the sender is still in the game (will contribute with other transactions).
 		} else {
 			accumulatedGas += gasLimit
-			selectedTransactions = append(selectedTransactions, item.selectCurrentTransaction())
+			selectedTransactions = append(selectedTransactions, item.selectCurrentTransaction(session))
 		}
 
 		// If there are more transactions in the same bunch (same sender as the popped item),

--- a/txcache/testutils_test.go
+++ b/txcache/testutils_test.go
@@ -2,6 +2,7 @@ package txcache
 
 import (
 	"encoding/binary"
+	"math/big"
 	"math/rand"
 	"sync"
 	"time"
@@ -178,6 +179,12 @@ func (wrappedTx *WrappedTransaction) withGasPrice(gasPrice uint64) *WrappedTrans
 func (wrappedTx *WrappedTransaction) withGasLimit(gasLimit uint64) *WrappedTransaction {
 	tx := wrappedTx.Tx.(*transaction.Transaction)
 	tx.GasLimit = gasLimit
+	return wrappedTx
+}
+
+func (wrappedTx *WrappedTransaction) withValue(value *big.Int) *WrappedTransaction {
+	tx := wrappedTx.Tx.(*transaction.Transaction)
+	tx.Value = value
 	return wrappedTx
 }
 


### PR DESCRIPTION
Make sure we don't select not-executable transactions (at all). Here, we handle transactions whose execution fee cannot be paid (anymore) by the sender.

Integration PR:
 - https://github.com/multiversx/mx-chain-go/pull/6637